### PR TITLE
Fix EOF handling in ProcessMemoryStream

### DIFF
--- a/Source/Gapotchenko.FX.Diagnostics.Process/Implementation/ProcessMemoryStream.cs
+++ b/Source/Gapotchenko.FX.Diagnostics.Process/Implementation/ProcessMemoryStream.cs
@@ -95,7 +95,7 @@ namespace Gapotchenko.FX.Diagnostics.Implementation
                 if (currentCount == 0)
                 {
                     // EOF
-                    return 0;
+                    return totalCount;
                 }
 
                 bool throwOnError = pageStart == m_FirstPageAddress;


### PR DESCRIPTION
Fixes https://github.com/gapotchenko/Gapotchenko.FX/issues/2

When trying to read more data than the remaining size of the memory region, `ProcessMemoryStream.Read` returns 0 instead of the number of bytes read so far. This causes the data to be truncated and the `ProcessBinaryReader` to throw an EndOfStreamException.

Somehow, this only happens if the target process has *a lot* of environment variables. My guess is that Windows pre-allocates a region that is larger than needed for the environment variables, and so ProcessMemoryStream usually manages to read all the variables without reaching the end. But when adding more variables than the limit, Windows re-allocates the region with exactly the right size (or at least with a smaller margin), and so it becomes more likely to hit this corner case.